### PR TITLE
Upgrade forge to 41.1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ mod_name=Thermal Expansion
 mod_version=10.0.0
 
 mc_version=1.19
-forge_version=41.0.98
+forge_version=41.1.0
 
 cofh_core_version=10.0.0.+
 thermal_core_version=10.0.0.+

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader = "javafml"
-loaderVersion = "[34,)"
+loaderVersion = "[41,)"
 issueTrackerURL = "https://github.com/cofh/feedback"
 license = "CoFH - Don't Be A Jerk (Learn, Don't Steal)"
 
@@ -28,7 +28,7 @@ side = "BOTH"
 [[dependencies.thermal_expansion]]
 modId = "forge"
 mandatory = true
-versionRange = "[41.0.43,)"
+versionRange = "[41.1.0,)"
 ordering = "AFTER"
 side = "BOTH"
 


### PR DESCRIPTION
Trying to build ThermalExpansion for 1.19 to have it running native on M1. Since some dependencies are rarely for 1.19.[1,2] stick with latest forge.